### PR TITLE
:lipstick: 优化“数据”界面时间显示的效果

### DIFF
--- a/app/src/main/res/layout/adapter_data.xml
+++ b/app/src/main/res/layout/adapter_data.xml
@@ -35,7 +35,7 @@
 
         <net.ankio.auto.ui.componets.IconView
             android:id="@+id/time"
-            android:layout_width="wrap_content"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginLeft="@dimen/padding"
             android:layout_marginRight="@dimen/padding"


### PR DESCRIPTION
“数据”界面时间显示会出现截断，修改样式，可以显示完全
![lQDPJx3lPvRakbPNDIDNBaCwhX4tmIlHjSEG8Ub1KowEAA_1440_3200](https://github.com/user-attachments/assets/2af5c7f1-f547-4787-8adc-8a5c95745303)
