### PR TITLE
:art: 优化应用图标显示逻辑

### DIFF
--- a/app/src/main/java/net/ankio/auto/ui/adapter/AppListAdapter.kt
+++ b/app/src/main/java/net/ankio/auto/ui/adapter/AppListAdapter.kt
@@ -55,7 +55,17 @@ class AppListAdapter(
         val binding = holder.binding
         val drawable = ResourcesCompat.getDrawable(context.resources, data.icon, null)
         val installedApp = App.isAppInstalled(data.packageName)
-        binding.appIcon.setImageDrawable(if (installedApp) drawable else toGrayscale(drawable!!))
+        // 获取应用图标
+        val appIcon = if (installedApp) {
+            getAppIcon(data.packageName) ?: ResourcesCompat.getDrawable(
+                context.resources,
+                data.icon,
+                null
+            )
+        } else {
+            drawable
+        }
+        binding.appIcon.setImageDrawable(if (installedApp) appIcon else toGrayscale(appIcon!!))
         binding.appName.text = data.name
         binding.appDesc.text = data.desc
         binding.appPackageName.text = data.packageName
@@ -75,5 +85,12 @@ class AppListAdapter(
         return drawable
     }
 
-
+    private fun getAppIcon(packageName: String): Drawable? {
+        return try {
+            context.packageManager.getApplicationIcon(packageName)
+        } catch (e: Exception) {
+            Logger.e("获取应用图标失败", e)
+            null
+        }
+    }
 }

--- a/commit-prompt.txt
+++ b/commit-prompt.txt
@@ -24,6 +24,7 @@ Instructions:
    - Generic messages like "Bug fix" or "Update file.txt"
    - Mentioning obvious details that can be seen in the diff
 6.- Generate in {local}
+7.- The final result should be given in {language}
 
 Output:
 - Provide only the commit message, without any additional explanation or commentary.


### PR DESCRIPTION
优化应用图标显示逻辑
- 优化应用图标获取逻辑，优先获取系统应用图标，提升应用图标显示效果，保证应用内图标一致性。
- 当获取系统图标失败时，使用默认图标，避免应用图标缺失。

修复 commit-prompt.txt 文件缺失 {language} 导致 AI-Git-Commit 插件无法使用的问题
 - 在最新的[AI-Git-Commit](https://plugins.jetbrains.com/plugin/24851-ai-git-commit)插件中，缺失 {language} 似乎会无法生成提交信息。