### PR TITLE
:lipstick: 修复悬浮提示倒计时文字抖动问题

### DIFF
--- a/app/src/main/res/layout/float_tip.xml
+++ b/app/src/main/res/layout/float_tip.xml
@@ -15,9 +15,9 @@
   ~
   -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="@dimen/btn_height_small"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:background="@drawable/bg_layout_tip"
     android:paddingStart="15dp"
     android:paddingEnd="15dp">
@@ -46,31 +46,32 @@
     <View
         android:layout_width="0dp"
         android:layout_height="0dp"
-        android:layout_weight="1"
-        />
+        android:layout_weight="1" />
 
     <TextView
         android:id="@+id/money"
         android:layout_width="wrap_content"
         android:layout_height="match_parent"
-        android:layout_marginEnd="10dp"
-        android:gravity="center_vertical"
+        android:layout_marginStart="10dp"
+        android:gravity="center"
 
         android:text="0.00"
         android:textColor="?attr/colorOnSecondaryContainer"
-        android:textSize="20sp" />
+        android:textSize="20sp"
+        android:typeface="monospace" />
 
     <TextView
         android:id="@+id/time"
         android:layout_width="wrap_content"
         android:layout_height="match_parent"
         android:layout_marginEnd="1dp"
-        android:gravity="center_vertical"
+        android:gravity="center_vertical|end"
+        android:minEms="2"
 
         android:text="0s"
         android:textColor="?attr/colorError"
         android:textSize="14sp"
-        />
+        android:typeface="monospace" />
 
 
 </LinearLayout>


### PR DESCRIPTION
修复悬浮提示倒计时文字抖动问题
- 文本使用等宽字体，提升显示效果
- 倒计时文本靠右对齐

附3张不同金额和秒数测试图片

![lQDPKHiIpPYR58vNDIDNBaCwmeuGPRxci-gG8-bvt2QxAA_1440_3200](https://github.com/user-attachments/assets/49709599-43fe-424d-9851-0eb8f63a5e7f)
![lQDPKHiJjdCs2MvNDIDNBaCw-WslthCvBTsG8-bw4dVKAA_1440_3200](https://github.com/user-attachments/assets/cb96f3d0-5994-4354-82db-3475440a30b1)
![lQDPKcjUgLiyaEvNDIDNBaCwSS0wsYdUMhwG8-byO2ezAA_1440_3200](https://github.com/user-attachments/assets/14d23a1e-239b-43ea-98ab-253e346a8d3a)
