### PR TITLE
:necktie: 修复“横屏勿扰”开闭的逻辑反转问题

### DIFF
--- a/server/src/main/java/org/ezbook/server/routes/JsRoute.kt
+++ b/server/src/main/java/org/ezbook/server/routes/JsRoute.kt
@@ -63,7 +63,6 @@ class JsRoute(private val session: ApplicationCall, private val context: Context
     }
 
 
-
     /**
      * 主函数，负责账单分析的整体流程。
      * 包括接收参数、数据解析、分析、分类处理以及最终结果的返回。
@@ -285,8 +284,9 @@ class JsRoute(private val session: ApplicationCall, private val context: Context
         userAction: Boolean
     ) {
         if (!billInfoModel.auto) {
-            val showInLandScape =
-                Db.get().settingDao().query(Setting.LANDSCAPE_DND)?.value != "false"
+            val landscapeDnd =
+                Db.get().settingDao().query(Setting.LANDSCAPE_DND)?.value != "true"
+            val showInLandScape = !landscapeDnd
             withContext(Dispatchers.Main) {
                 runCatching {
                     startAutoPanel(billInfoModel, parent, showInLandScape)


### PR DESCRIPTION
“横屏勿扰”在设置中的开闭LANDSCAPE_DND和悬浮窗拉起的showInLandScape需要进行逻辑反转，否则会出现开启“横屏勿扰”功能的时候，悬浮窗依旧正常拉起，反之。（如果我没理解错的话）