### PR TITLE
:bug: 修复 Gemini 中转代理 404（例如 Cloudflare WorkPage 中转）

### DIFF
--- a/server/src/main/java/org/ezbook/server/ai/providers/GeminiProvider.kt
+++ b/server/src/main/java/org/ezbook/server/ai/providers/GeminiProvider.kt
@@ -23,12 +23,16 @@ class GeminiProvider : BaseAIProvider() {
 
     override var model: String = "gemini-2.0-flash"
 
+    private suspend fun base(): String {
+        val base = getApiUri().trimEnd('/')
+        return if (base.endsWith("/v1beta/models")) base else "$base/v1beta/models"
+    }
 
     /**
      * 获取可用模型列表
      */
     override suspend fun getAvailableModels(): List<String> = withContext(Dispatchers.IO) {
-        val url = "$${getApiUri()}?key=${getApiKey()}"
+        val url = "${base()}?key=${getApiKey()}"
         val request = Request.Builder()
             .url(url)
             .get()
@@ -60,7 +64,7 @@ class GeminiProvider : BaseAIProvider() {
     ): Result<String> =
         withContext(Dispatchers.IO) {
             val path = if (onChunk === null) "generateContent" else "streamGenerateContent?alt=sse"
-            val url = "${getApiUri()}/$model:$path"
+            val url = "${base()}/$model:$path"
             val requestBody = mapOf(
                 "contents" to listOf(
                     mapOf(


### PR DESCRIPTION
规范化 GeminiProvider base URL 自动补全 /v1beta/models

变更：
- 统一规范化 Gemini 基地址，若未包含 /v1beta/models 自动补全，兼容 Google API 直连与代理根域名。
- 修正 getAvailableModels 的 URL 模板问题。
- 统一非流式/流式接口的路径构造，避免路径缺失导致 404。

验证：
- Provider=Gemini；Base URL= 代理根域名；
- 测试连接与非流式调用成功，返回有效内容；真机实测通过。

影响范围：
- 仅 server/ai/providers/GeminiProvider.kt，不影响其他 Provider。