### PR TITLE
:sparkles: 在账单页面添加搜索功能并优化分页加载逻辑 #1374

### DIFF
--- a/app/src/main/java/net/ankio/auto/http/api/BillAPI.kt
+++ b/app/src/main/java/net/ankio/auto/http/api/BillAPI.kt
@@ -15,6 +15,7 @@
 
 package net.ankio.auto.http.api
 
+import android.net.Uri
 import com.google.gson.Gson
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -83,29 +84,22 @@ object BillAPI {
      * @param type 账单类型列表
      * @param year 年份
      * @param month 月份
+     * @param keyword 搜索关键字
      * @return 按日期分组的账单列表
      */
     suspend fun listGrouped(
         type: MutableList<String>,
         year: Int? = null,
-        month: Int? = null
+        month: Int? = null,
+        keyword: String = "" // 新增关键字参数
     ): List<OrderGroup> =
         withContext(Dispatchers.IO) {
-            val typeName = listOf(
-                BillState.Edited.name,
-                BillState.Synced.name,
-                BillState.Wait2Edit.name
-            ).joinToString()
-            val syncType = if (type.isNotEmpty()) type.joinToString() else typeName
+            val syncType = type.joinToString(",")
+            val timeQuery = if (year != null && month != null) "&year=$year&month=$month" else ""
+            // 在 URL 中增加 keyword 参数
+            val url = "bill/list-grouped?type=$syncType$timeQuery&keyword=${Uri.encode(keyword)}"
 
             return@withContext runCatchingExceptCancel {
-                // 时间参数改为可选：传入年月时按月筛选；不传时返回全部时间范围
-                val timeQuery = if (year != null && month != null) {
-                    "&year=$year&month=$month"
-                } else {
-                    ""
-                }
-                val url = "bill/list-grouped?type=$syncType$timeQuery"
                 val resp = LocalNetwork.get<List<OrderGroup>>(url).getOrThrow()
                 resp.data ?: emptyList()
             }.getOrElse {

--- a/app/src/main/java/net/ankio/auto/ui/api/BasePageFragment.kt
+++ b/app/src/main/java/net/ankio/auto/ui/api/BasePageFragment.kt
@@ -31,7 +31,7 @@ abstract class BasePageFragment<T, VB : ViewBinding> : BaseFragment<VB>() {
     var page = 1
 
     /** 每页数据条数 */
-    val pageSize = 100
+    open val pageSize = 100
 
     /**
      * 加载数据的抽象方法，子类需要实现
@@ -46,7 +46,9 @@ abstract class BasePageFragment<T, VB : ViewBinding> : BaseFragment<VB>() {
     abstract fun onCreateAdapter(): RecyclerView.Adapter<*>
 
     /** 是否正在加载数据 */
-    private var isLoading = false
+    protected var isLoading = false
+
+    protected var loadJob: kotlinx.coroutines.Job? = null
 
     /** 是否还有更多数据可以加载 */
     private var hasMoreData = true
@@ -177,6 +179,25 @@ abstract class BasePageFragment<T, VB : ViewBinding> : BaseFragment<VB>() {
         resetPage()
         hasMoreData = true
         statusPage.showLoading()
+        
+        loadJob?.cancel()
+        isLoading = false
+        
+        loadDataInside()
+    }
+
+    /**
+     * 静默重新加载数据
+     * 不显示全屏加载动画，避免用户输入时界面闪烁
+     */
+    fun reloadSilently() {
+        Logger.d("静默重新加载数据：从第一页开始")
+        resetPage()
+        hasMoreData = true
+        
+        loadJob?.cancel()
+        isLoading = false
+        
         loadDataInside()
     }
 
@@ -197,26 +218,36 @@ abstract class BasePageFragment<T, VB : ViewBinding> : BaseFragment<VB>() {
         isLoading = true
         Logger.d("开始加载数据：第${page}页")
 
-        launch {
+        loadJob = launch {
 
-            // 在IO线程中执行数据加载，避免阻塞UI
-            val resultData = withIO { loadData() }
+            try {
+                // 在IO线程中执行数据加载，避免阻塞UI
+                val resultData = withIO { loadData() }
 
-            // 根据加载结果更新UI状态
-            if (resultData.isEmpty()) {
-                Logger.d("第${page}页无数据返回")
-                statusPage.showEmpty()
-                hasMoreData = false
-                callback?.invoke(true, false)
-            } else {
-                Logger.d("第${page}页加载成功：${resultData.size}条数据")
-                baseAdapter?.submitItems(resultData)
-                statusPage.showContent()
-                hasMoreData = resultData.size >= pageSize
-                callback?.invoke(true, hasMoreData)
-                restoreScrollPosition()
+                // 根据加载结果更新UI状态
+                if (resultData.isEmpty()) {
+                    Logger.d("第${page}页无数据返回")
+                    if (page == 1) {
+                        statusPage.showEmpty()
+                    }
+                    hasMoreData = false
+                    callback?.invoke(true, false)
+                } else {
+                    Logger.d("第${page}页加载成功：${resultData.size}条数据")
+                    baseAdapter?.submitItems(resultData)
+                    statusPage.showContent()
+                    hasMoreData = resultData.size >= pageSize
+                    callback?.invoke(true, hasMoreData)
+                    restoreScrollPosition()
+                }
+            } catch (e: Exception) {
+                if (page == 1) {
+                    statusPage.showError()
+                }
+                callback?.invoke(false, hasMoreData)
+            } finally {
+                isLoading = false
             }
-            isLoading = false
         }
 
     }

--- a/app/src/main/java/net/ankio/auto/ui/fragment/BillFragment.kt
+++ b/app/src/main/java/net/ankio/auto/ui/fragment/BillFragment.kt
@@ -17,7 +17,9 @@
 package net.ankio.auto.ui.fragment
 
 import android.os.Bundle
+import android.view.MenuItem
 import android.view.View
+import androidx.appcompat.widget.SearchView
 import androidx.recyclerview.widget.RecyclerView
 import net.ankio.auto.R
 import net.ankio.auto.databinding.FragmentBillBinding
@@ -26,6 +28,7 @@ import net.ankio.auto.storage.Logger
 import net.ankio.auto.ui.adapter.BillAdapter
 import net.ankio.auto.ui.api.BasePageFragment
 import net.ankio.auto.ui.api.BaseSheetDialog
+import net.ankio.auto.ui.components.MaterialSearchView
 import net.ankio.auto.ui.components.WrapContentLinearLayoutManager
 import net.ankio.auto.ui.dialog.BillEditorDialog
 import net.ankio.auto.ui.dialog.BillMoreDialog
@@ -55,15 +58,19 @@ open class BillFragment : BasePageFragment<OrderGroup, FragmentBillBinding>() {
     private var currentMonth: Int =
         java.util.Calendar.getInstance().get(java.util.Calendar.MONTH) + 1
 
+    private var searchKeyword = ""
+
+    override val pageSize: Int = Int.MAX_VALUE
+
     /**
      * 加载数据：使用服务端分组，避免客户端重复分组导致的性能问题
      */
     override suspend fun loadData(): List<OrderGroup> {
         // 服务端已经完成分组，直接返回
         return if (timeFilterMode == TimeFilterMode.ALL) {
-            BillAPI.listGrouped(syncType)
+            BillAPI.listGrouped(syncType, keyword = searchKeyword)
         } else {
-            BillAPI.listGrouped(syncType, currentYear, currentMonth)
+            BillAPI.listGrouped(syncType, currentYear, currentMonth, searchKeyword)
         }
     }
 
@@ -277,6 +284,38 @@ open class BillFragment : BasePageFragment<OrderGroup, FragmentBillBinding>() {
                 else -> false
             }
         }
+        setUpSearch()
+    }
+
+    private var searchJob: kotlinx.coroutines.Job? = null
+
+    private fun setUpSearch() {
+        val searchItem = binding.topAppBar.menu.findItem(R.id.action_search) ?: return
+        val searchView = searchItem.actionView as? MaterialSearchView ?: return
+
+        searchView.setOnQueryTextListener(object : SearchView.OnQueryTextListener {
+            override fun onQueryTextSubmit(query: String?): Boolean = true
+            override fun onQueryTextChange(newText: String?): Boolean {
+                searchKeyword = newText ?: ""
+                searchJob?.cancel()
+                searchJob = launch {
+                    kotlinx.coroutines.delay(300)
+                    reloadSilently() // 实时触发静默刷新，避免闪烁
+                }
+                return true
+            }
+        })
+
+        // 监听搜索框展开和收起
+        searchItem.setOnActionExpandListener(object : MenuItem.OnActionExpandListener {
+            override fun onMenuItemActionExpand(item: MenuItem): Boolean = true
+            override fun onMenuItemActionCollapse(item: MenuItem): Boolean {
+                searchKeyword = ""
+                searchJob?.cancel()
+                reload()
+                return true
+            }
+        })
     }
 
     // 抽取删除数据的逻辑

--- a/app/src/main/res/menu/bill_menu.xml
+++ b/app/src/main/res/menu/bill_menu.xml
@@ -16,6 +16,13 @@
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">
     <item
+        android:id="@+id/action_search"
+        android:icon="@drawable/menu_icon_search"
+        android:iconTint="?colorOnBackground"
+        android:title="@string/item_search"
+        app:actionViewClass="net.ankio.auto.ui.components.MaterialSearchView"
+        app:showAsAction="always|collapseActionView" />
+    <item
         android:id="@+id/item_sync"
         android:icon="@drawable/ic_sync2"
         android:iconTint="?colorOnBackground"

--- a/server/src/main/java/org/ezbook/server/server/BillRoutes.kt
+++ b/server/src/main/java/org/ezbook/server/server/BillRoutes.kt
@@ -56,10 +56,11 @@ fun Route.billRoutes() {
                 BillState.Synced.name,
                 BillState.Wait2Edit.name
             )
-            val type = call.request.queryParameters["type"]?.split(", ") ?: defaultStates
+            val type = call.request.queryParameters["type"]?.split(",") ?: defaultStates
 
             val year = call.request.queryParameters["year"]?.toIntOrNull()
             val month = call.request.queryParameters["month"]?.toIntOrNull()
+            val keyword = call.request.queryParameters["keyword"] ?: ""
 
             // 计算时间范围：
             // - 传 year+month：按月过滤
@@ -81,11 +82,21 @@ fun Route.billRoutes() {
                 Long.MAX_VALUE
             }
 
-            ServerLog.d("获取分组账单列表：year=$year, month=$month, type=$type")
+            ServerLog.d("获取分组账单列表：year=$year, month=$month, type=$type, keyword=$keyword")
 
             // 获取整月数据（不分页）
             val bills = Db.get().billInfoDao().getBillsByTimeRange(startTime, endTime)
                 .filter { it.groupId == -1L && type.contains(it.state.name) }
+                .filter {
+                    keyword.isEmpty() ||
+                            it.shopName.contains(keyword, ignoreCase = true) ||
+                            it.shopItem.contains(keyword, ignoreCase = true) ||
+                            it.remark.contains(keyword, ignoreCase = true) ||
+                            it.cateName.contains(keyword, ignoreCase = true) ||
+                            it.tags.contains(keyword, ignoreCase = true) ||
+                            it.accountNameFrom.contains(keyword, ignoreCase = true) ||
+                            it.accountNameTo.contains(keyword, ignoreCase = true)
+                }
                 .sortedByDescending { it.time }
 
             // 服务端按日期分组


### PR DESCRIPTION
<img width="1440" height="477" alt="screenshot" src="https://github.com/user-attachments/assets/fe50f123-bc4a-4cc4-9723-39e93bb30599" />
本pr使用了AI辅助开发。

主要修改： 添加了账单的搜索功能
“顺手优化” (Drive-by fix): 优化分页加载逻辑
  1. 修复了“无限加载”的死循环（Paging Loop）
   * 原有问题：BasePageFragment 内部写死了一个逻辑：如果一次加载返回的数据大于等于 100
     条，它就认为“还有下一页”，当用户滑动到底部时会自动去加载第二页。但是，您的账单列表（BillFragment）的 API
     接口是一次性返回整月所有数据的，根本不支持分页。如果某个月的账单超过了 100 条，您一滑到底部，它就会疯狂地重复请求这个月的全部数据，导致应用卡顿甚至崩溃。
   * 做了什么：我们将底层固定的 pageSize 改成了可配置的，并在 BillFragment 中将其设置为
     Int.MAX_VALUE。这样底层逻辑就知道“我已经加载完所有数据了”，从而彻底杜绝了无限重复加载的死循环。

  2. 修复了搜索/刷新时的 UI 闪烁（竞态条件）
   * 原有问题：之前底层的加载状态锁（isLoading）没有使用安全的 try-finally 块保护。如果在搜索或网络请求过程中发生异常，这个锁可能永远不会被释放（变成
     false），导致页面卡死，再也无法加载新数据。
   * 做了什么：用 try { ... } finally { isLoading = false }
     结构重写了核心加载代码，保证无论搜索成功、失败还是网络异常，状态锁都能正确重置。同时新增了
     reloadSilently()（静默重载）方法，这样在快速输入搜索词时，列表会在后台平滑更新，而不会每敲一个字母屏幕就疯狂闪烁一个巨大的“加载中”的圈圈。

  3. 修复了“空状态”的错误覆盖
   * 原有问题：在原有的分页代码中，只要某次请求返回了 0 条数据，它就会直接显示“这里空空如也”的插图。这意味着如果正在浏览第2页，且第2页刚好没数据，它会把第1页已经看到的内容全部抹掉，换成一张空状态图。
   * 做了什么：增加了一个简单的判断：只有在请求第1页（page == 1）且没有数据时，才显示空状态图。保证了分页逻辑的严谨性。

我在本地构建并测试了我的数据，搜索功能可以如期使用