### PR TITLE
:bug: 修复失效的 Star History 图表

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,9 +138,9 @@ git clone https://github.com/AutoAccountingOrg/AutoAccounting
 > 提交代码/PR 前请**务必**先阅读 [贡献指南](CONTRIBUTING.md)。
 
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=AutoAccountingOrg/AutoAccounting&type=Date&theme=dark" />
-  <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=AutoAccountingOrg/AutoAccounting&type=Date" />
-  <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=AutoAccountingOrg/AutoAccounting&type=Date" />
+  <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=AutoAccountingOrg/AutoAccounting&type=Date&theme=dark" />
+  <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=AutoAccountingOrg/AutoAccounting&type=Date" />
+  <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=AutoAccountingOrg/AutoAccounting&type=Date" />
 </picture>
 
 ## 📝 License


### PR DESCRIPTION
当前 README 中的 Star History 图表因 GitHub 星标 API 限制已经失效，无法正常加载。

本 PR 将图表地址迁移至新的数据源，该方案无需 API Token，并使用更稳定的数据来源，确保星标趋势图可以长期正常展示。

相关变更仅涉及 README 中的图表链接，不影响任何功能代码。