### PR TITLE
:sparkles: 增加只读账单 Webhook 导出

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -191,6 +191,7 @@ dependencies {
     implementation(libs.androidx.activity)
     implementation(libs.androidx.constraintlayout)
     implementation(libs.androidx.lifecycle.runtime.ktx)
+    implementation(libs.androidx.work.runtime.ktx)
 
     // Html转换
     implementation(libs.html.ktx)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,6 +13,8 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
+    <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
 
 
     <!--    &lt;!&ndash; 6.0–10.0 普通存储 &ndash;&gt;
@@ -96,6 +98,16 @@
             android:permission="android.permission.BROADCAST_SMS">
             <intent-filter>
                 <action android:name="android.provider.Telephony.SMS_RECEIVED" />
+            </intent-filter>
+        </receiver>
+
+        <receiver
+            android:name=".export.BillExportAlarmReceiver"
+            android:enabled="true"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
+                <action android:name="net.ankio.auto.BILL_EXPORT_ALARM" />
             </intent-filter>
         </receiver>
 

--- a/app/src/main/java/net/ankio/auto/App.kt
+++ b/app/src/main/java/net/ankio/auto/App.kt
@@ -24,6 +24,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import net.ankio.auto.http.LicenseNetwork
+import net.ankio.auto.export.BillExportScheduler
 import net.ankio.auto.storage.Logger
 import net.ankio.auto.ui.utils.ToastUtils
 import net.ankio.auto.utils.CoroutineUtils
@@ -31,6 +32,7 @@ import net.ankio.auto.utils.ExceptionHandler
 import net.ankio.auto.utils.PrefManager
 import net.ankio.auto.utils.PrefManager.darkTheme
 import net.ankio.auto.utils.SystemUtils
+import org.ezbook.server.tools.BillExportSignal
 import rikka.material.app.LocaleDelegate
 import java.util.Locale
 import kotlin.coroutines.CoroutineContext
@@ -81,6 +83,8 @@ open class App : Application() {
         initBuglyIfRelease()
         initUI()
         initNetwork()
+        BillExportSignal.register { BillExportScheduler.enqueueImmediate(this) }
+        BillExportScheduler.configure(this)
     }
 
     /**

--- a/app/src/main/java/net/ankio/auto/export/BillExportAlarmReceiver.kt
+++ b/app/src/main/java/net/ankio/auto/export/BillExportAlarmReceiver.kt
@@ -1,0 +1,20 @@
+package net.ankio.auto.export
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+
+class BillExportAlarmReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent) {
+        if (intent.action == Intent.ACTION_BOOT_COMPLETED) {
+            BillExportScheduler.configure(context)
+            return
+        }
+        if (intent.action == BillExportScheduler.ACTION_ALARM) {
+            BillExportScheduler.handleAlarm(
+                context,
+                intent.getIntExtra(BillExportWorker.KEY_DAY_OFFSET, 0),
+            )
+        }
+    }
+}

--- a/app/src/main/java/net/ankio/auto/export/BillExportScheduler.kt
+++ b/app/src/main/java/net/ankio/auto/export/BillExportScheduler.kt
@@ -1,0 +1,83 @@
+package net.ankio.auto.export
+
+import android.app.AlarmManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import androidx.work.Data
+import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.ExistingWorkPolicy
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.PeriodicWorkRequestBuilder
+import androidx.work.WorkManager
+import net.ankio.auto.utils.PrefManager
+import java.time.ZoneId
+import java.time.ZonedDateTime
+import java.util.concurrent.TimeUnit
+
+object BillExportScheduler {
+    private const val PERIODIC_NAME = "bill-export-hourly"
+    private const val IMMEDIATE_NAME = "bill-export-immediate"
+    const val ACTION_ALARM = "net.ankio.auto.BILL_EXPORT_ALARM"
+
+    fun configure(context: Context) {
+        val work = WorkManager.getInstance(context)
+        if (!PrefManager.billExportEnabled) {
+            work.cancelUniqueWork(PERIODIC_NAME)
+            cancelAlarms(context)
+            return
+        }
+        val periodic = PeriodicWorkRequestBuilder<BillExportWorker>(1, TimeUnit.HOURS)
+            .build()
+        work.enqueueUniquePeriodicWork(PERIODIC_NAME, ExistingPeriodicWorkPolicy.UPDATE, periodic)
+        scheduleAlarm(context, 21, 20, 0, 2120)
+        scheduleAlarm(context, 0, 30, -1, 30)
+    }
+
+    fun enqueueImmediate(context: Context, dayOffset: Int = 0) {
+        if (!PrefManager.billExportEnabled) return
+        val request = OneTimeWorkRequestBuilder<BillExportWorker>()
+            .setInputData(Data.Builder().putInt(BillExportWorker.KEY_DAY_OFFSET, dayOffset).build())
+            .build()
+        WorkManager.getInstance(context)
+            .enqueueUniqueWork(IMMEDIATE_NAME, ExistingWorkPolicy.KEEP, request)
+    }
+
+    fun handleAlarm(context: Context, dayOffset: Int) {
+        enqueueImmediate(context, dayOffset)
+        configure(context)
+    }
+
+    private fun scheduleAlarm(context: Context, hour: Int, minute: Int, offset: Int, requestCode: Int) {
+        val manager = context.getSystemService(AlarmManager::class.java)
+        val now = ZonedDateTime.now(ZoneId.of("Asia/Shanghai"))
+        var next = now.withHour(hour).withMinute(minute).withSecond(0).withNano(0)
+        if (!next.isAfter(now)) next = next.plusDays(1)
+        val pending = alarmIntent(context, offset, requestCode)
+        val millis = next.toInstant().toEpochMilli()
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S || manager.canScheduleExactAlarms()) {
+            manager.setExactAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, millis, pending)
+        } else {
+            manager.setAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, millis, pending)
+        }
+    }
+
+    private fun alarmIntent(context: Context, offset: Int, requestCode: Int): PendingIntent {
+        val intent = Intent(context, BillExportAlarmReceiver::class.java)
+            .setAction(ACTION_ALARM)
+            .putExtra(BillExportWorker.KEY_DAY_OFFSET, offset)
+        return PendingIntent.getBroadcast(
+            context,
+            requestCode,
+            intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+        )
+    }
+
+    private fun cancelAlarms(context: Context) {
+        val manager = context.getSystemService(AlarmManager::class.java)
+        manager.cancel(alarmIntent(context, 0, 2120))
+        manager.cancel(alarmIntent(context, -1, 30))
+    }
+}

--- a/app/src/main/java/net/ankio/auto/export/BillExportWorker.kt
+++ b/app/src/main/java/net/ankio/auto/export/BillExportWorker.kt
@@ -1,0 +1,41 @@
+package net.ankio.auto.export
+
+import android.content.Context
+import android.os.SystemClock
+import androidx.work.CoroutineWorker
+import androidx.work.WorkerParameters
+import net.ankio.auto.storage.Logger
+import java.time.LocalDate
+import java.time.ZoneId
+
+class BillExportWorker(context: Context, params: WorkerParameters) : CoroutineWorker(context, params) {
+    override suspend fun doWork(): Result {
+        val started = SystemClock.elapsedRealtime()
+        val offset = inputData.getInt(KEY_DAY_OFFSET, 0)
+        val day = LocalDate.now(ZoneId.of("Asia/Shanghai")).plusDays(offset.toLong())
+        val result = BillExporter.exportDay(day)
+        return result.fold(
+            onSuccess = {
+                Logger.d(
+                    "账单导出完成: day=$day states=${it.stateCounts} pulled=${it.pulled} " +
+                        "posted=${it.posted} failed=0 elapsed_ms=${SystemClock.elapsedRealtime() - started}"
+                )
+                Result.success()
+            },
+            onFailure = { error ->
+                val failure = error as? BillExportFailure
+                Logger.e(
+                    "账单导出失败: day=$day states=${failure?.stateCounts.orEmpty()} " +
+                        "posted=${failure?.posted ?: 0} failed=1 " +
+                        "error=${failure?.kind ?: "unknown"} " +
+                        "elapsed_ms=${SystemClock.elapsedRealtime() - started}"
+                )
+                Result.failure()
+            },
+        )
+    }
+
+    companion object {
+        const val KEY_DAY_OFFSET = "day_offset"
+    }
+}

--- a/app/src/main/java/net/ankio/auto/export/BillExporter.kt
+++ b/app/src/main/java/net/ankio/auto/export/BillExporter.kt
@@ -1,0 +1,83 @@
+package net.ankio.auto.export
+
+import com.google.gson.Gson
+import net.ankio.auto.http.api.BillAPI
+import net.ankio.auto.utils.PrefManager
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import org.ezbook.server.constant.BillState
+import org.ezbook.server.db.model.BillInfoModel
+import java.time.LocalDate
+import java.time.ZoneId
+import java.util.concurrent.TimeUnit
+
+data class BillExportResult(val stateCounts: Map<String, Int>, val posted: Int) {
+    val pulled: Int get() = stateCounts.values.sum()
+}
+
+class BillExportFailure(
+    val kind: String,
+    val stateCounts: Map<String, Int>,
+    val posted: Int,
+    cause: Throwable,
+) : Exception(kind, cause)
+
+object BillExporter {
+    private val zone = ZoneId.of("Asia/Shanghai")
+    private val gson = Gson()
+    private val client = OkHttpClient.Builder()
+        .connectTimeout(15, TimeUnit.SECONDS)
+        .readTimeout(20, TimeUnit.SECONDS)
+        .writeTimeout(20, TimeUnit.SECONDS)
+        .build()
+    private val states = listOf(BillState.Synced, BillState.Edited, BillState.Wait2Edit)
+
+    suspend fun exportDay(day: LocalDate): Result<BillExportResult> {
+        val counts = linkedMapOf<String, Int>()
+        var posted = 0
+        return runCatching {
+            check(PrefManager.billExportEnabled) { "disabled" }
+            val endpoint = PrefManager.billExportUrl.trim()
+            val token = PrefManager.billExportToken.trim()
+            check(endpoint.startsWith("https://")) { "endpoint_must_be_https" }
+            check(token.isNotEmpty()) { "token_missing" }
+
+            val start = day.atStartOfDay(zone).toInstant().toEpochMilli()
+            val end = day.plusDays(1).atStartOfDay(zone).toInstant().toEpochMilli()
+
+            // Pull all three states before posting anything. An empty successful list is valid;
+            // any failed local call aborts the entire run and leaves NAS files untouched.
+            val bills = mutableListOf<BillInfoModel>()
+            for (state in states) {
+                val stateBills = BillAPI.exportList(state, start, end).getOrThrow()
+                counts[state.name] = stateBills.size
+                bills += stateBills
+            }
+
+            for (bill in bills) {
+                val request = Request.Builder()
+                    .url(endpoint)
+                    .header("Authorization", "Bearer $token")
+                    .header("Content-Type", "application/json; charset=utf-8")
+                    .post(gson.toJson(bill).toRequestBody("application/json; charset=utf-8".toMediaType()))
+                    .build()
+                client.newCall(request).execute().use { response ->
+                    check(response.isSuccessful) { "nas_http_${response.code}" }
+                }
+                posted++
+            }
+            BillExportResult(counts.toMap(), posted)
+        }.recoverCatching { error ->
+            throw BillExportFailure(shortError(error), counts.toMap(), posted, error)
+        }
+    }
+
+    private fun shortError(error: Throwable): String = when {
+        error.message in setOf("disabled", "endpoint_must_be_https", "token_missing") -> error.message!!
+        error.message?.startsWith("nas_http_") == true -> error.message!!
+        error is java.io.IOException -> "network_io"
+        else -> error.javaClass.simpleName.take(40)
+    }
+}

--- a/app/src/main/java/net/ankio/auto/http/api/BillAPI.kt
+++ b/app/src/main/java/net/ankio/auto/http/api/BillAPI.kt
@@ -32,6 +32,18 @@ import org.ezbook.server.tools.runCatchingExceptCancel
  * 所有方法都是挂起函数，需要在协程作用域内调用
  */
 object BillAPI {
+    /** Strict read-only export call; failures remain distinguishable from an empty result. */
+    suspend fun exportList(
+        state: BillState,
+        startTime: Long,
+        endTime: Long
+    ): Result<List<BillInfoModel>> = withContext(Dispatchers.IO) {
+        runCatchingExceptCancel {
+            val path = "bill/export/list?state=${state.name}&start=$startTime&end=$endTime"
+            LocalNetwork.get<List<BillInfoModel>>(path).getOrThrow().data ?: emptyList()
+        }
+    }
+
     /**
      * 添加或更新账单信息
      * @param billInfoModel 账单信息模型

--- a/app/src/main/java/net/ankio/auto/ui/fragment/settings/DataManagementPreferenceFragment.kt
+++ b/app/src/main/java/net/ankio/auto/ui/fragment/settings/DataManagementPreferenceFragment.kt
@@ -23,6 +23,7 @@ import androidx.core.net.toUri
 import androidx.preference.Preference
 import androidx.preference.PreferenceDataStore
 import net.ankio.auto.R
+import net.ankio.auto.export.BillExportScheduler
 import net.ankio.auto.storage.Logger
 import net.ankio.auto.storage.backup.BackupManager
 import net.ankio.auto.storage.backup.BackupResult
@@ -121,6 +122,7 @@ class DataManagementPreferenceFragment : BasePreferenceFragment() {
 
         // WebDAV配置
         setupWebDAVConfigPreferences()
+        setupBillExportPreferences()
 
         // 备份保留数量设置
         setPreferenceClickListener("setting_backup_keep_count") {
@@ -301,6 +303,34 @@ class DataManagementPreferenceFragment : BasePreferenceFragment() {
         }
     }
 
+    private fun setupBillExportPreferences() {
+        setPreferenceClickListener("bill_export_url") {
+            showEditDialog(
+                getString(R.string.setting_bill_export_url),
+                PrefManager.billExportUrl,
+                "https://example.invalid/autoaccounting/v1/bills"
+            ) {
+                PrefManager.billExportUrl = it
+                updatePreferenceDisplays()
+            }
+        }
+        setPreferenceClickListener("bill_export_token") {
+            showEditDialog(
+                getString(R.string.setting_bill_export_token),
+                PrefManager.billExportToken,
+                "Bearer token",
+                true
+            ) {
+                PrefManager.billExportToken = it
+                updatePreferenceDisplays()
+            }
+        }
+        setPreferenceClickListener("bill_export_test") {
+            BillExportScheduler.enqueueImmediate(requireContext())
+            ToastUtils.info(getString(R.string.setting_bill_export_test_queued))
+        }
+    }
+
     /**
      * 显示编辑对话框
      */
@@ -418,6 +448,14 @@ class DataManagementPreferenceFragment : BasePreferenceFragment() {
             summary = if (PrefManager.webdavPassword.isNotEmpty()) "••••••••"
             else getString(R.string.setting_webdav_password_summary)
         }
+        findPreference<Preference>("bill_export_url")?.summary =
+            PrefManager.billExportUrl.ifEmpty { getString(R.string.setting_bill_export_url_summary) }
+        findPreference<Preference>("bill_export_token")?.summary =
+            if (PrefManager.billExportToken.isEmpty()) {
+                getString(R.string.setting_bill_export_token_summary)
+            } else {
+                "••••••••"
+            }
     }
 
     /**
@@ -468,6 +506,7 @@ class DataManagementPreferenceFragment : BasePreferenceFragment() {
             return when (key) {
                 "auto_backup" -> PrefManager.autoBackup
                 "setting_use_webdav" -> PrefManager.useWebdav
+                "bill_export_enabled" -> PrefManager.billExportEnabled
                 else -> defValue
             }
         }
@@ -476,8 +515,11 @@ class DataManagementPreferenceFragment : BasePreferenceFragment() {
             when (key) {
                 "auto_backup" -> PrefManager.autoBackup = value
                 "setting_use_webdav" -> PrefManager.useWebdav = value
+                "bill_export_enabled" -> {
+                    PrefManager.billExportEnabled = value
+                    BillExportScheduler.configure(net.ankio.auto.autoApp)
+                }
             }
         }
     }
 }
-

--- a/app/src/main/java/net/ankio/auto/utils/PrefManager.kt
+++ b/app/src/main/java/net/ankio/auto/utils/PrefManager.kt
@@ -892,6 +892,19 @@ object PrefManager {
         get() = getBoolean("home_privacy_mode", false)
         set(value) = putBoolean("home_privacy_mode", value)
 
+    /** Side-channel bill export is opt-in and keeps its credential on device. */
+    var billExportEnabled: Boolean
+        get() = getBoolean("bill_export_enabled", false)
+        set(value) = putBoolean("bill_export_enabled", value)
+
+    var billExportUrl: String
+        get() = getString("bill_export_url", "")
+        set(value) = putString("bill_export_url", value.trim())
+
+    var billExportToken: String
+        get() = getString("bill_export_token", "")
+        set(value) = putString("bill_export_token", value.trim())
+
     /**
      * 是否已通过应用内入口打开过帮助文档（与「关于 → 官网」同一地址）。
      * 为 true 时首页不再弹出阅读文档提醒。

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -1064,4 +1064,14 @@
     <string name="switch_transfer_direction">切换转账方向</string>
     <string name="approximate_rate_format">≈ %1$s %2$s</string>
     <string name="delete_data_count">删除（%d）</string>
+    <string name="setting_bill_export_category">账单导出</string>
+    <string name="setting_bill_export_enabled">同步账单到 NAS</string>
+    <string name="setting_bill_export_enabled_summary">每小时只读导出，不修改记账同步队列</string>
+    <string name="setting_bill_export_url">NAS 接收地址</string>
+    <string name="setting_bill_export_url_summary">完整 HTTPS 地址，以 /autoaccounting/v1/bills 结尾</string>
+    <string name="setting_bill_export_token">NAS 令牌</string>
+    <string name="setting_bill_export_token_summary">独立 Bearer Token，仅保存在本机</string>
+    <string name="setting_bill_export_test">立即导出</string>
+    <string name="setting_bill_export_test_summary">读取并上传今天的三种账单状态</string>
+    <string name="setting_bill_export_test_queued">账单导出已启动</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1101,4 +1101,14 @@
     <string name="delete_data_count">Delete (%d)</string>
     <string name="version_format" translatable="false">v%s</string>
     <string name="bill_amount_format" translatable="false">%1$s%2$s%3$s</string>
+    <string name="setting_bill_export_category">Bill export</string>
+    <string name="setting_bill_export_enabled">Export bills to NAS</string>
+    <string name="setting_bill_export_enabled_summary">Read-only hourly export; never changes the accounting sync queue</string>
+    <string name="setting_bill_export_url">NAS endpoint</string>
+    <string name="setting_bill_export_url_summary">Full HTTPS endpoint ending in /autoaccounting/v1/bills</string>
+    <string name="setting_bill_export_token">NAS token</string>
+    <string name="setting_bill_export_token_summary">Independent Bearer token stored on this device</string>
+    <string name="setting_bill_export_test">Export now</string>
+    <string name="setting_bill_export_test_summary">Read and upload today’s three bill states</string>
+    <string name="setting_bill_export_test_queued">Bill export started</string>
 </resources>

--- a/app/src/main/res/xml/settings_data_management.xml
+++ b/app/src/main/res/xml/settings_data_management.xml
@@ -1,6 +1,33 @@
 <?xml version="1.0" encoding="utf-8"?><!-- 数据管理：自动备份、本地备份、WebDAV备份 -->
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
 
+    <PreferenceCategory android:title="@string/setting_bill_export_category">
+        <rikka.material.preference.MaterialSwitchPreference
+            android:key="bill_export_enabled"
+            android:defaultValue="false"
+            android:icon="@drawable/ic_sync"
+            android:title="@string/setting_bill_export_enabled"
+            android:summary="@string/setting_bill_export_enabled_summary" />
+        <androidx.preference.Preference
+            android:key="bill_export_url"
+            android:dependency="bill_export_enabled"
+            android:icon="@drawable/ic_open_in_new"
+            android:title="@string/setting_bill_export_url"
+            android:summary="@string/setting_bill_export_url_summary" />
+        <androidx.preference.Preference
+            android:key="bill_export_token"
+            android:dependency="bill_export_enabled"
+            android:icon="@drawable/ic_lock"
+            android:title="@string/setting_bill_export_token"
+            android:summary="@string/setting_bill_export_token_summary" />
+        <androidx.preference.Preference
+            android:key="bill_export_test"
+            android:dependency="bill_export_enabled"
+            android:icon="@drawable/ic_sync"
+            android:title="@string/setting_bill_export_test"
+            android:summary="@string/setting_bill_export_test_summary" />
+    </PreferenceCategory>
+
     <!-- 自动备份 -->
     <PreferenceCategory android:title="@string/setting_category_auto_backup">
         <rikka.material.preference.MaterialSwitchPreference
@@ -84,4 +111,3 @@
     </PreferenceCategory>
 
 </PreferenceScreen>
-

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -73,6 +73,7 @@ quickjsAndroid = "35726a9d28"
 materialThemeBuilder = "1.5.1"
 autoresconfig = "1.2.2"
 lifecycleService = "2.10.0"
+workManager = "2.10.5"
 # Machine learning (Columbus-style back tap detection)
 liteRt = "2.1.5"
 junit = "4.13.2"
@@ -82,6 +83,7 @@ appcompatVersion = "1.7.1"
 [libraries]
 # AndroidX Core
 androidx-lifecycle-runtime-ktx = { module = "androidx.lifecycle:lifecycle-runtime-ktx", version.ref = "lifecycleRuntimeKtx" }
+androidx-work-runtime-ktx = { module = "androidx.work:work-runtime-ktx", version.ref = "workManager" }
 androidx-navigation-fragment-ktx = { module = "androidx.navigation:navigation-fragment-ktx", version.ref = "navigationFragment" }
 androidx-navigation-ui-ktx = { module = "androidx.navigation:navigation-ui-ktx", version.ref = "navigationFragment" }
 androidx-room-compiler = { module = "androidx.room:room-compiler", version.ref = "roomVersion" }

--- a/server/src/main/java/org/ezbook/server/db/dao/BillInfoDao.kt
+++ b/server/src/main/java/org/ezbook/server/db/dao/BillInfoDao.kt
@@ -83,6 +83,14 @@ interface BillInfoDao {
         endTime: Long
     ): List<BillInfoModel>
 
+    /** Read-only export query. It deliberately does not touch sync state. */
+    @Query("SELECT * FROM BillInfoModel WHERE groupId = -1 AND state = :state AND time >= :startTime AND time < :endTime ORDER BY time ASC, id ASC")
+    suspend fun exportByStateAndTimeRange(
+        state: BillState,
+        startTime: Long,
+        endTime: Long
+    ): List<BillInfoModel>
+
     @Query("DELETE FROM BillInfoModel WHERE groupId = :groupId")
     suspend fun deleteGroup(groupId: Long)
 

--- a/server/src/main/java/org/ezbook/server/server/BillRoutes.kt
+++ b/server/src/main/java/org/ezbook/server/server/BillRoutes.kt
@@ -30,6 +30,7 @@ import org.ezbook.server.models.OrderGroupDto
 import org.ezbook.server.models.ResultModel
 import org.ezbook.server.log.ServerLog
 import org.ezbook.server.tools.StatisticsService
+import org.ezbook.server.tools.BillExportSignal
 import org.ezbook.server.tools.roundAmount
 import java.text.SimpleDateFormat
 import java.util.Locale
@@ -155,6 +156,7 @@ fun Route.billRoutes() {
             } else {
                 Db.get().billInfoDao().insert(bill)
             }
+            BillExportSignal.notifyCommitted()
             call.respond(ResultModel.ok(id))
         }
 
@@ -197,6 +199,24 @@ fun Route.billRoutes() {
         }
 
         /**
+         * GET /bill/export/list - read-only side-channel export.
+         * Requires one concrete state and a [start,end) millisecond window.
+         */
+        get("/export/list") {
+            val state = call.request.queryParameters["state"]?.let {
+                runCatching { BillState.valueOf(it) }.getOrNull()
+            }
+            val start = call.request.queryParameters["start"]?.toLongOrNull()
+            val end = call.request.queryParameters["end"]?.toLongOrNull()
+            if (state == null || start == null || end == null || start >= end) {
+                call.respond(ResultModel.error(400, "state/start/end 参数无效"))
+                return@get
+            }
+            val result = Db.get().billInfoDao().exportByStateAndTimeRange(state, start, end)
+            call.respond(ResultModel.ok(result))
+        }
+
+        /**
          * POST /bill/status - 更新账单同步状态
          *
          * @param body 包含id和sync的JSON对象
@@ -210,6 +230,7 @@ fun Route.billRoutes() {
             val status = json?.get("sync")?.asBoolean ?: false
             val newState = if (status) BillState.Synced else BillState.Edited
             Db.get().billInfoDao().updateStatus(id, newState)
+            BillExportSignal.notifyCommitted()
             call.respond(ResultModel.ok(0))
         }
 

--- a/server/src/main/java/org/ezbook/server/tools/BillExportSignal.kt
+++ b/server/src/main/java/org/ezbook/server/tools/BillExportSignal.kt
@@ -1,0 +1,18 @@
+package org.ezbook.server.tools
+
+/**
+ * Process-local post-commit signal. The server never performs external I/O;
+ * the Android app registers a listener that enqueues durable background work.
+ */
+object BillExportSignal {
+    @Volatile
+    private var listener: (() -> Unit)? = null
+
+    fun register(listener: (() -> Unit)?) {
+        this.listener = listener
+    }
+
+    fun notifyCommitted() {
+        listener?.invoke()
+    }
+}

--- a/server/src/main/java/org/ezbook/server/tools/BillService.kt
+++ b/server/src/main/java/org/ezbook/server/tools/BillService.kt
@@ -282,6 +282,8 @@ class BillService(
                 // 拉起悬浮窗（仅外部数据）
                 if (!analysisParams.fromAppData) startAutoPanel(billInfo, parentBill)
 
+                BillExportSignal.notifyCommitted()
+
                 // 返回父账单供后续使用
                 parentBill
             }


### PR DESCRIPTION
## 变更说明

关联 #1389。

本 PR 增加一个默认关闭的账单 Webhook 导出能力，用于用户自建的数据备份和自动化链路。

- 新增 `/bill/export/list` 本机只读接口，按状态及 `[start,end)` 时间窗查询，固定 `groupId=-1`，不调用或修改现有同步队列。
- Android 端完整读取 `Synced`、`Edited`、`Wait2Edit` 三态后，逐条 POST 完整 `BillInfoModel` 到用户配置的 HTTPS Webhook。任一状态读取失败时不会发送。
- 账单入库、人工编辑和同步状态更新后，通过进程内信号触发 WorkManager unique work。
- 每小时后台执行，并通过 AlarmManager 在 21:20 补跑当天、00:30 补跑前一天，开机后恢复调度。
- 数据管理设置新增启用开关、Webhook URL、独立 Bearer Token 和立即导出入口。
- 日志仅保留日期、三态数量、成功数量、短错误类型及耗时，不记录 Token 或完整账单。

## 兼容性

- 功能默认关闭。
- 不修改现有同步队列、账单状态或删除行为。
- Webhook 地址强制要求 HTTPS。

## 验证

- `:server:compileDebugKotlin`
- `:app:compileDebugKotlin`
- `:app:assembleDebug`
- `:app:assembleRelease`
- Release APK 通过 zipalign 与 APK Signature Scheme v2 校验。

受当前环境限制，没有可用 ADB 设备，尚未进行真机验证。